### PR TITLE
Update the wasm wrapper of aiken/uplc to the conway era

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
-      - uses: actions/checkout@v3
+          version: "latest"
+      - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: ./build.sh
       - uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,8 +897,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "uplc-wrapper"
-version = "0.0.1"
+name = "uplc-wasm"
+version = "0.1.0"
 dependencies = [
  "getrandom",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,16 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
-dependencies = [
- "traitobject",
- "typeable",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,18 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-
-[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,10 +900,8 @@ dependencies = [
 name = "uplc-wrapper"
 version = "0.0.1"
 dependencies = [
- "error",
  "getrandom",
  "js-sys",
- "k256",
  "uplc",
  "wasm-bindgen",
  "wee_alloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -921,19 +921,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if 1.0.0",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -946,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -956,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -969,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wee_alloc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -248,7 +254,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi",
@@ -351,7 +357,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -379,6 +385,12 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miette"
@@ -720,7 +732,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -916,6 +928,7 @@ dependencies = [
  "k256",
  "uplc",
  "wasm-bindgen",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -936,7 +949,7 @@ version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -983,6 +996,40 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-error = "0.1.9"
-uplc = { git = "https://github.com/aiken-lang/aiken.git"}
+uplc = { git = "https://github.com/aiken-lang/aiken.git" }
 wasm-bindgen = "0.2.89"
-k256 = { version = "0.13.0" }
 js-sys = "0.3.61"
 getrandom = { version = "0.2", features = ["js"] }
 wee_alloc = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 uplc = { git = "https://github.com/aiken-lang/aiken.git" }
-wasm-bindgen = "0.2.89"
-js-sys = "0.3.61"
+wasm-bindgen = "0.2.93"
+js-sys = "0.3.70"
 getrandom = { version = "0.2", features = ["js"] }
 wee_alloc = "0.4.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ wasm-bindgen = "0.2.89"
 k256 = { version = "0.13.0" }
 js-sys = "0.3.61"
 getrandom = { version = "0.2", features = ["js"] }
+wee_alloc = "0.4.5"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ codegen-units = 1
 opt-level = "z"
 lto = true
 debug = false
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "uplc-wrapper"
-version = "0.0.1"
+name = "uplc-wasm"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,11 @@
 name = "uplc-wasm"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "A WebAssembly (wasm) wrapper for the uplc crate"
+repository = "https://github.com/mpizenberg/uplc-wasm"
+license = "Apache-2.0"
+keywords = ["cardano", "wasm", "uplc"]
+categories = ["algorithms"]
 
 [lib]
 crate-type = ["cdylib"]
@@ -12,8 +15,9 @@ crate-type = ["cdylib"]
 uplc = { git = "https://github.com/aiken-lang/aiken.git" }
 wasm-bindgen = "0.2.93"
 js-sys = "0.3.70"
-getrandom = { version = "0.2", features = ["js"] }
 wee_alloc = "0.4.5"
+# required for wasm usage of getrandom
+getrandom = { version = "0.2", features = ["js"] }
 
 [profile.release]
 codegen-units = 1

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,5 @@
-rm -rf pkg
-rm -rf pkg-node
-rm -rf pkg-web
-wasm-pack build -t nodejs
+rm -rf pkg pkg-node pkg-web
+wasm-pack build --target nodejs
 mv pkg pkg-node
 wasm-pack build
 mv pkg pkg-web

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 rm -rf pkg pkg-node pkg-web
 wasm-pack build --target nodejs
 mv pkg pkg-node
-wasm-pack build
+wasm-pack build --target web
 mv pkg pkg-web

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@ use js_sys;
 use uplc::tx;
 use wasm_bindgen::prelude::*;
 
+// Use `wee_alloc` as the global allocator.
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
 #[wasm_bindgen]
 pub fn eval_phase_two_raw(
     tx_bytes: &[u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,26 +9,30 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[wasm_bindgen]
 pub fn eval_phase_two_raw(
     tx_bytes: &[u8],
-    utxos_bytes_x: Vec<js_sys::Uint8Array>,
-    utxos_bytes_y: Vec<js_sys::Uint8Array>,
+    utxos_refs_bytes: Vec<js_sys::Uint8Array>,
+    utxos_outputs_bytes: Vec<js_sys::Uint8Array>,
     cost_mdls_bytes: &[u8],
-    initial_budget_n: u64,
-    initial_budget_d: u64,
-    slot_config_x: u64,
-    slot_config_y: u64,
-    slot_config_z: u32,
+    cpu_budget: u64,
+    mem_budget: u64,
+    slot_config_zero_time: u64,
+    slot_config_zero_slot: u64,
+    slot_config_slot_length: u32,
 ) -> Result<Vec<js_sys::Uint8Array>, JsValue> {
-    let utxos_bytes = utxos_bytes_x
+    let utxos_bytes = utxos_refs_bytes
         .into_iter()
-        .zip(utxos_bytes_y.into_iter())
+        .zip(utxos_outputs_bytes.into_iter())
         .map(|(x, y)| (x.to_vec(), y.to_vec()))
         .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
     return tx::eval_phase_two_raw(
         tx_bytes,
         &utxos_bytes,
         cost_mdls_bytes,
-        (initial_budget_n, initial_budget_d),
-        (slot_config_x, slot_config_y, slot_config_z),
+        (cpu_budget, mem_budget),
+        (
+            slot_config_zero_time,
+            slot_config_zero_slot,
+            slot_config_slot_length,
+        ),
         false,
         |_| (),
     )


### PR DESCRIPTION
The main changes of this PR are the following:

- the crate name was changed to "uplc-wasm" with version 0.1.0 (from "uplc-wrapper" at 0.0.1)
- repository source was added (will need to change to antibody-cardano)
- updated the wasm-bindgen and js-sys deps
- now using wasm-opt as a post-process step, this save some kbs of payload
- now using wee_alloc instead of the default allocator, this save some other kbs of payload
- now using "--target web" instead of the default target for the web stuff. This is to be compatible with generic ES module code, and not tied to webpack.
- renamed "utxos_bytes_x/y" to "utxos_refs_bytes" and "utxos_outputs_bytes"
- renamed "initial_budget_n/d" to "cpu_budget" and "mem_budget"
- renamed "slot_config_x/y/z" to corresponding parameter names